### PR TITLE
Change Package.name to match URL slug

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@
 import PackageDescription
 
 let package = Package(
-  name: "SE0288_IsPower",
+  name: "swift-se0288-is-power",
   products: [
     .library(
       name: "SE0288_IsPower",


### PR DESCRIPTION
This prevented usage via `import StandardLibraryPreview` from Swift 5.4 on Linux